### PR TITLE
fix(languages): claim stack before entering an engine, so Cedar's rec…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,6 +2437,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_norway",
+ "stacker",
  "tracing",
 ]
 

--- a/crates/permguard-cli/src/engine/workspace/cases.rs
+++ b/crates/permguard-cli/src/engine/workspace/cases.rs
@@ -264,10 +264,10 @@ pub fn compile(snapshot: &Snapshot, manifest: &Manifest) -> Result<Compiled> {
         )
         .map_err(|why| err(why.to_string()))?;
 
-        let evaluator: std::sync::Arc<dyn Evaluator> = evaluating
-            .compile(&held.policies, &held.artifacts)
-            .map_err(|error| err(format!("partition `{}`: {error}", entry.name)))?
-            .into();
+        let evaluator: std::sync::Arc<dyn Evaluator> =
+            languages::headroom::with(|| evaluating.compile(&held.policies, &held.artifacts))
+                .map_err(|error| err(format!("partition `{}`: {error}", entry.name)))?
+                .into();
         partitions.insert(entry.name.clone(), evaluator);
         languages.insert(entry.name.clone(), runtime.language.name.clone());
     }

--- a/crates/permguard-cli/src/main.rs
+++ b/crates/permguard-cli/src/main.rs
@@ -65,6 +65,17 @@ use crate::trace::Trace;
 pub use crate::failure::{EXIT_NOT_READY, EXIT_READY, EXIT_SOFTWARE, EXIT_UNREACHABLE, EXIT_USAGE};
 
 fn main() -> ExitCode {
+    // Claimed once, for the whole command: a policy engine guards its own recursion by asking how
+    // much stack is left, and on a musl build — which every Linux release is — the answer for the
+    // process's first thread is the pages that happen to be mapped rather than the stack it has.
+    // An engine that believes it has 128 KiB declines to parse, deserialize or evaluate anything
+    // at all, so `permguard test` answered "recursion limit reached" on Linux for policies that
+    // passed everywhere else. Claiming the room here covers every call this command makes; the
+    // engine boundaries in `permguard-languages` cover the threads it hands work to.
+    permguard_languages::headroom::with(run_command)
+}
+
+fn run_command() -> ExitCode {
     // Parsed by hand so that a wrong command line exits `EX_USAGE` rather than clap's default of
     // 2 — which is a status this CLI has already given a meaning of its own.
     let matches = match args::command().try_get_matches() {

--- a/crates/permguard-data-plane/src/authz/snapshot.rs
+++ b/crates/permguard-data-plane/src/authz/snapshot.rs
@@ -296,10 +296,11 @@ pub fn compile(mirror: &Path, head: &Head, partition: &str) -> Result<Arc<Partit
 
     let footprint = collected.footprint();
     let policies = collected.policies.len();
-    let evaluator: Arc<dyn Evaluator> = engine
-        .compile(&collected.policies, &collected.artifacts)
-        .map_err(Refusal::Incompatible)?
-        .into();
+    let evaluator: Arc<dyn Evaluator> = permguard_languages::headroom::with(|| {
+        engine.compile(&collected.policies, &collected.artifacts)
+    })
+    .map_err(Refusal::Incompatible)?
+    .into();
 
     // What the manifest declared about this partition's history, against what its schemas turned
     // out to say. Checked here rather than only where the ledger was authored, because a mirror is

--- a/crates/permguard-languages/Cargo.toml
+++ b/crates/permguard-languages/Cargo.toml
@@ -27,6 +27,12 @@ permguard-events.workspace = true
 # engine and Dogwood's can coexist. Revisit when that generator relaxes its pin.
 cedar-policy = "4.11"
 regorus = "0.11"
+# Stack headroom for the engines, not a new capability: Cedar's evaluator refuses to interpret an
+# expression when `stacker::remaining_stack()` reports less than a megabyte left, and answers
+# "recursion limit reached" however shallow the policy is. Already in this graph — cedar-policy
+# carries it — so it is a direct dependency of the crate that has to guarantee the headroom rather
+# than a transitive accident. See `evaluate_all`.
+stacker = "0.1"
 # The Rego partition schema: JSON Schema, compiled once at load. Already in this
 # workspace's graph — regorus carries it — so it is a direct dependency of the
 # crate that actually validates with it rather than a transitive accident.

--- a/crates/permguard-languages/src/dogwood/compiled.rs
+++ b/crates/permguard-languages/src/dogwood/compiled.rs
@@ -843,7 +843,10 @@ impl crate::temporal::Temporal for CompiledDogwood {
             })?;
             // The verdicts of a replay are discarded: what is being rebuilt is the *history*, and
             // a decision made now against a partial replay would be a decision nobody asked for.
-            let _ = fresh.is_authorized(&event);
+            // Entered with room to recurse in, like every other call into an engine — see
+            // `crate::headroom`; a replay that declined for want of stack would rebuild a history
+            // missing the very events it is replaying.
+            let _ = crate::headroom::with(|| fresh.is_authorized(&event));
         }
 
         let engine = self.engine(history)?;
@@ -909,7 +912,11 @@ impl crate::temporal::Temporal for CompiledDogwood {
                     .observed
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-                authorizer.is_authorized(&event)
+                // Entered with room to recurse in: this is where a Dogwood partition
+                // actually decides, and a thread whose stack the platform under-reports would
+                // have every policy here answer "recursion limit reached". See
+                // `crate::headroom`.
+                crate::headroom::with(|| authorizer.is_authorized(&event))
             }
             // A history whose lock a panicking thread left poisoned is one nobody can vouch for.
             // Fail closed rather than reach past the poison for the state.
@@ -1048,17 +1055,19 @@ impl CompiledDogwood {
             })
             .collect();
 
-        Entities::from_json_value(serde_json::Value::Array(store), Some(&self.cedar_schema))
-            .map(|_| ())
-            .map_err(|error| {
-                Refused::new(
-                    "event_entities_rejected",
-                    format!(
-                        "the attributed entity store does not conform to this partition's action \
+        crate::headroom::with(|| {
+            Entities::from_json_value(serde_json::Value::Array(store), Some(&self.cedar_schema))
+        })
+        .map(|_| ())
+        .map_err(|error| {
+            Refused::new(
+                "event_entities_rejected",
+                format!(
+                    "the attributed entity store does not conform to this partition's action \
                          schema: {error}"
-                    ),
-                )
-            })
+                ),
+            )
+        })
     }
 }
 

--- a/crates/permguard-languages/src/evaluate.rs
+++ b/crates/permguard-languages/src/evaluate.rs
@@ -254,7 +254,10 @@ pub fn evaluate_all(work: Vec<(std::sync::Arc<dyn Evaluator>, Query)>) -> Vec<An
                             .to_owned(),
                     )
                 } else {
-                    let verdict = evaluator.evaluate(&query);
+                    // Entered with room to recurse in, whatever thread this is: an engine
+                    // handed a stack it cannot measure declines rather than answers. See
+                    // `crate::headroom`.
+                    let verdict = crate::headroom::with(|| evaluator.evaluate(&query));
                     // A synchronous provider cannot be interrupted once it has
                     // entered upstream's engine. That does not make its late
                     // answer valid: in particular, a permit produced after the

--- a/crates/permguard-languages/src/headroom.rs
+++ b/crates/permguard-languages/src/headroom.rs
@@ -1,0 +1,57 @@
+// Copyright (c) 2022 Nitro Agility S.r.l.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The stack an engine is entered with.
+//!
+//! # Why a policy engine needs this at all
+//!
+//! Evaluating policy is recursive over the shape of an expression, so an engine that recursed
+//! freely would let a deep enough policy overflow the stack — a crash, in the one process that
+//! must never stop answering. Cedar's evaluator therefore guards itself: before interpreting an
+//! expression it asks [`stacker::remaining_stack`] for a megabyte of headroom, and if it is not
+//! there it declines the whole evaluation with "recursion limit reached". Dogwood lowers to the
+//! same engine and inherits the same guard.
+//!
+//! That guard is only as good as the answer to "how much stack is left", and on one of the
+//! platforms Permguard ships to that answer is wrong. musl does not track the stack of the
+//! process's first thread: its `pthread_getattr_np` probes the pages currently mapped and reports
+//! what it finds — around 128 KiB — where glibc and Darwin report the real eight megabytes. Every
+//! Linux release binary is musl-static, and both engine entry points can run on that first thread
+//! ([`crate::fanout::Fanout::run`] deliberately evaluates the first partition on the calling
+//! thread, and the temporal path decides on the caller's). The result was a two-line policy
+//! answering "recursion limit reached" on Linux while the same workspace passed on macOS, and
+//! passed again over gRPC, where the work lands on a spawned thread whose bounds musl does know.
+//!
+//! # Why growing, rather than a bigger thread
+//!
+//! A larger stack would not have helped: the number musl reports has nothing to do with the stack
+//! the thread was given, so `RUST_MIN_STACK` and an explicit `stack_size` change the reported
+//! headroom not at all. What fixes it is claiming the room and *saying so* — [`stacker::maybe_grow`]
+//! allocates a segment and sets the limit stacker itself reports afterwards, so the engine's own
+//! check reads the stack it was actually handed.
+//!
+//! Applied at the engine boundary rather than inside one engine: how much stack it needs is the
+//! engine's business, and guaranteeing the headroom is this crate's. A thread that already has the
+//! room pays one comparison for it.
+
+/// The headroom an engine is guaranteed before it is entered.
+///
+/// A megabyte, because that is what Cedar's own guard demands: below it, its evaluator declines
+/// rather than risk the stack. Matching it means the guard never fires for want of room — only for
+/// a policy that is genuinely too deep for [`GROW_TO`].
+const RED_ZONE: usize = 1024 * 1024;
+
+/// How much stack is claimed when the headroom is short.
+///
+/// Eight megabytes: what the platforms Permguard ships to give a thread by default, so an engine on
+/// a stack-starved thread is neither more nor less constrained than one on a healthy thread.
+/// Claimed on demand, and only when [`RED_ZONE`] is not already available.
+const GROW_TO: usize = 8 * 1024 * 1024;
+
+/// Runs `work` with at least [`RED_ZONE`] of stack beneath it.
+///
+/// Every call into a policy engine goes through here. See the module documentation for what goes
+/// wrong when one does not.
+pub fn with<T>(work: impl FnOnce() -> T) -> T {
+    stacker::maybe_grow(RED_ZONE, GROW_TO, work)
+}

--- a/crates/permguard-languages/src/lib.rs
+++ b/crates/permguard-languages/src/lib.rs
@@ -34,6 +34,7 @@ mod rego;
 pub mod artifact;
 pub mod evaluate;
 pub mod fanout;
+pub mod headroom;
 pub mod input;
 pub mod lookup;
 pub mod manifest_file;

--- a/crates/permguard-languages/src/request.rs
+++ b/crates/permguard-languages/src/request.rs
@@ -423,7 +423,10 @@ impl Asking {
             )
         })?;
         if let Some(evaluator) = target.evaluator {
-            evaluator.check_input(&normalized).map_err(|why| {
+            // Entered with room to recurse in: checking an entity store means deserializing it
+            // in the engine, which recurses over the graph and is guarded by the engine's own
+            // stack check. See `crate::headroom`.
+            crate::headroom::with(|| evaluator.check_input(&normalized)).map_err(|why| {
                 malformed(
                     "partition_input_schema",
                     format!("`partition_inputs.{}`: {why}", target.name),


### PR DESCRIPTION
fix(languages): claim stack before entering a policy engine

<!-- Copyright (c) 2022 Nitro Agility S.r.l. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

## What this changes

Offline evaluation is deterministic on musl builds — every Linux release binary and the
container image. `permguard test` now agrees with the data plane on byte-identical policies
instead of failing at random on shallow ones.

## Why

Cedar guards its own recursion by asking `stacker::remaining_stack()` for a megabyte of
headroom and declining the whole evaluation without it. musl does not track the stack of the
process's first thread: it probes the mapped pages and reports ~128 KiB where glibc and
Darwin report the real 8 MiB. The CLI evaluates on that thread (`Fanout::run` takes the first
partition on the caller, and the temporal path decides there too), the data plane does not —
it decides on tokio workers, whose bounds musl does report.

So `permguard test` answered `recursion limit reached` or `error during entity
deserialization` for two-level-deep policies, and because the reported number drifts with how
many pages happen to be mapped, the same unchanged tree answered differently run to run:

```
basics:            19/25 runs "3 passed, 2 failed"      remote: 5/5
release-pipeline:  18/20 runs "12 passed, 11 failed"    remote: 23/23
```

A bigger stack does not help: what musl reports has nothing to do with the stack the thread
was given, so neither `RUST_MIN_STACK` nor an explicit `stack_size` changes the answer. The
fix claims the room and *declares* it — `stacker::maybe_grow` sets the limit stacker reports
afterwards, so the engine's check reads the stack it was handed. New
`permguard-languages/src/headroom.rs`, applied at the CLI entrypoint and at each engine
boundary: `Evaluator::evaluate`, `Evaluator::check_input`, `Temporal::apply` / `rebuild` /
`check`, and `Evaluating::compile`. Guarding evaluation alone is not enough — the
deserialization failure comes from `check_input`, and Dogwood decides through
`Temporal::apply`.

All three shipped examples are green and stable across repeated runs: `basics` 5/5,
`release-pipeline` 23/23, `dogwood-session-access` 8/8.

## Contributor License Agreement

By opening this pull request you confirm that you have read and accept the
[Permguard Contributor License Agreement](https://github.com/permguard/.github/blob/main/CLA.md).
You keep ownership of what you contribute; the CLA grants Nitro Agility S.r.l.
the rights it needs to distribute it as part of Permguard, now and under future
licensing terms.

- [x] I have read and accept the Permguard Contributor License Agreement

## Checklist

- [x] `task check` passes locally (lint, structural checks, tests)
- [ ] Tests cover the behaviour, not just the code path
- [ ] `CHANGELOG.md` updated under *Unreleased*, if this changes anything an operator can see
- [x] Any new configuration key, flag, metric, exit status or `reason` code is documented
- [x] `docs/compatibility.md` still describes reality, if this touches one of the listed interfaces

## Interfaces touched

- [x] Container images, chart values, or anything in a release artifact