### PR TITLE
fix(cli): land the incoming head in the working tree, so a pull canno…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ is cut.
 
 ### Fixed
 
+- `pull` now lands the incoming head in the working tree instead of only creating the files that
+  were missing. A file the remote moved and the author had not is advanced; a file the remote
+  dropped and the author had not touched is removed; a file both sides moved is a conflict, and the
+  pull refuses without advancing the checkpoint or writing anything. Previously the checkpoint moved
+  while the tree kept the old content, so the next `apply` — which diffs the tree against the
+  checkpoint — silently reverted the other author's commit and reported success. The refusal names
+  each file and the object to read it with (`permguard objects cat <digest>`); `pull --resolved`
+  accepts the working tree as already reconciled and advances.
+- `pull`, `checkout` and `clone` now count what they advanced and removed alongside what they
+  wrote. "0 files written" alone read like a no-op on a pull that changed content. `pull` also
+  says `Already up to date.` only when it truly had nothing to do: a refused pull leaves its
+  objects in the local store, so the `--resolved` retry fetches none and still moves the ref.
 - Event and decision ingest now validates signer-manifest changes before replacing any retained
   envelope or record. Reusing one `kid` with different key material is refused without changing
   the acknowledged evidence.

--- a/crates/permguard-cli/src/args.rs
+++ b/crates/permguard-cli/src/args.rs
@@ -323,9 +323,16 @@ pub enum Command {
         /// The ledger to bind to, as `<remote>/<zone>/<ledger>[@<ref>]`.
         reference: String,
     },
-    /// Fetch the latest changes, verify them, and materialize what is missing.
-    #[command(after_help = "Examples:\n  permguard pull\n  permguard pull -v")]
-    Pull,
+    /// Fetch the latest changes, verify them, and land them in the working tree.
+    #[command(after_help = "Examples:\n  permguard pull\n  permguard pull -v\n  \
+                            permguard pull --resolved")]
+    Pull {
+        /// Accept the working tree as already reconciled with the incoming
+        /// head: land what is missing and advance, instead of refusing the
+        /// files both sides changed. Use it after merging a conflict by hand.
+        #[arg(long)]
+        resolved: bool,
+    },
     /// Scan the sources and build the local snapshot.
     #[command(
         after_help = "Examples:\n  permguard refresh\n  permguard refresh -o json | jq '.root'"

--- a/crates/permguard-cli/src/commands/workspace.rs
+++ b/crates/permguard-cli/src/commands/workspace.rs
@@ -393,7 +393,10 @@ pub enum WorkspaceOp {
     Checkout {
         reference: String,
     },
-    Pull,
+    Pull {
+        /// The working tree is reconciled: land and advance, do not refuse.
+        resolved: bool,
+    },
     Refresh,
     Validate,
     Test {
@@ -697,6 +700,9 @@ pub fn workspace_command(
                     head: pulled.head,
                     fetched: pulled.fetched,
                     materialized: pulled.materialized,
+                    updated: pulled.updated,
+                    removed: pulled.removed,
+                    previous_counter: pulled.previous_counter,
                 },
                 format,
                 trace,
@@ -737,14 +743,17 @@ pub fn workspace_command(
                     head: pulled.head,
                     fetched: pulled.fetched,
                     materialized: pulled.materialized,
+                    updated: pulled.updated,
+                    removed: pulled.removed,
+                    previous_counter: pulled.previous_counter,
                 },
                 format,
                 trace,
             )?;
         }
-        WorkspaceOp::Pull => {
+        WorkspaceOp::Pull { resolved } => {
             let remote = tracked_remote(trace)?;
-            let pulled = ws.pull(&remote).map_err(usage)?;
+            let pulled = ws.pull(&remote, resolved).map_err(usage)?;
             render(
                 &PullReport {
                     action: "pull",
@@ -754,6 +763,9 @@ pub fn workspace_command(
                     head: pulled.head,
                     fetched: pulled.fetched,
                     materialized: pulled.materialized,
+                    updated: pulled.updated,
+                    removed: pulled.removed,
+                    previous_counter: pulled.previous_counter,
                 },
                 format,
                 trace,

--- a/crates/permguard-cli/src/engine/workspace/sync.rs
+++ b/crates/permguard-cli/src/engine/workspace/sync.rs
@@ -46,6 +46,15 @@ pub struct PullOutcome {
     pub counter: u64,
     pub fetched: usize,
     pub materialized: Vec<String>,
+    /// Files the incoming head moved forward that the author had not touched.
+    pub updated: Vec<String>,
+    /// Files the incoming head dropped that the author had not touched.
+    pub removed: Vec<String>,
+    /// The counter this workspace held before the pull, when it held one — so
+    /// the report can tell a pull that moved the ref from one that found
+    /// nothing to do, which the object count alone cannot: a refused pull
+    /// leaves its objects in the store, so the retry fetches none.
+    pub previous_counter: Option<u64>,
 }
 
 impl Workspace<'_> {
@@ -199,7 +208,7 @@ impl Workspace<'_> {
     /// materialization between the proof and the checkpoint — a failure
     /// writing sources can never leave the checkpoint claiming more than
     /// the disk holds.
-    pub fn pull(&self, remote: &dyn Remote) -> Result<PullOutcome> {
+    pub fn pull(&self, remote: &dyn Remote, resolved: bool) -> Result<PullOutcome> {
         let config = self.config()?;
         let ledger = config
             .ledger
@@ -214,6 +223,9 @@ impl Workspace<'_> {
             ledger_id: ledger.ledger_id.clone(),
             r#ref: r#ref.clone(),
         };
+        let previous_counter = config::read_checkpoint(self.store, &r#ref)
+            .map_err(err)?
+            .map(|held| held.counter);
         let verified = pull::fetch_closure(
             self.store,
             crate::engine::workspace::inventory::OBJECTS_DIR,
@@ -223,7 +235,7 @@ impl Workspace<'_> {
         )
         .map_err(err)?;
 
-        let materialized = self.materialize(&verified.head)?;
+        let landed = self.materialize(&verified.head, resolved)?;
 
         pull::commit_checkpoint(self.store, &config::checkpoint_path(&r#ref), &verified)
             .map_err(err)?;
@@ -232,7 +244,10 @@ impl Workspace<'_> {
             head: verified.head.to_string(),
             counter: verified.counter,
             fetched: verified.fetched,
-            materialized,
+            materialized: landed.created(),
+            updated: landed.updated(),
+            removed: landed.removals,
+            previous_counter,
         })
     }
 
@@ -256,7 +271,7 @@ impl Workspace<'_> {
         });
         self.save_config(&config)?;
         config::write_head(self.store, r#ref).map_err(err)?;
-        match self.pull(remote) {
+        match self.pull(remote, false) {
             Ok(outcome) => Ok(outcome),
             // A ledger with no ref yet is not an error to bind to: the first
             // apply will create it. The binding stays; the pull found nothing.
@@ -268,6 +283,9 @@ impl Workspace<'_> {
                     counter: 0,
                     fetched: 0,
                     materialized: Vec::new(),
+                    updated: Vec::new(),
+                    removed: Vec::new(),
+                    previous_counter: None,
                 })
             }
             Err(error) => Err(error),
@@ -343,103 +361,318 @@ impl Workspace<'_> {
         })
     }
 
-    /// Materializes what the workspace lacks from a snapshot: the manifest
-    /// file when there is none, and one new file per missing policy. Files
-    /// the author already keeps are never touched.
-    fn materialize(&self, head: &Digest) -> Result<Vec<String>> {
+    /// Materializes the incoming head into the working tree.
+    ///
+    /// Three-way, per file: the tracked head is the base, the working tree is
+    /// the author's, the incoming head is the remote's. A file only one side
+    /// moved follows that side — the remote's change lands, the author's
+    /// stays pending for `apply`. A file both sides moved is a conflict, and
+    /// a conflict stops the pull before a byte is written.
+    ///
+    /// Advancing the checkpoint over a file the tree does not hold is how a
+    /// later `apply` silently reverts somebody else's commit: the diff is
+    /// taken tree-against-checkpoint, so content the tree never received
+    /// reads as a deliberate deletion. The checkpoint may only claim what
+    /// the disk holds.
+    fn materialize(&self, head: &Digest, resolved: bool) -> Result<Materialization> {
+        let plan = self.plan_materialization(head)?;
+        if !resolved && !plan.conflicts.is_empty() {
+            return Err(err(plan.refusal()));
+        }
+        for (path, content) in plan.creates.iter().chain(&plan.updates) {
+            self.store.write(path, content).map_err(err)?;
+        }
+        for path in &plan.removals {
+            self.store.remove(path).map_err(err)?;
+        }
+        Ok(plan)
+    }
+
+    /// Decides what the incoming head does to the working tree, without
+    /// touching it — so a conflict costs nothing and leaves nothing behind.
+    fn plan_materialization(&self, head: &Digest) -> Result<Materialization> {
         let commit = load_commit(self.store, head)?;
-        let root = load_tree(self.store, &commit.tree)?;
-        let mut written = Vec::new();
+        let incoming = head_contents(self.store, head)?;
+        let base = match tracked_head(self.store)? {
+            Some(previous) => head_contents(self.store, &previous)?,
+            // Nothing tracked yet: a clone, where every file is a create.
+            None => HeadContents::default(),
+        };
+        let mut plan = Materialization::default();
 
         // The manifest: written as manifest.yml only when no manifest file
-        // exists — the CLI never picks between two silently.
+        // exists — the CLI never picks between two silently, and it does not
+        // three-way a generated document against a hand-written one either.
         if manifest_file::find(self.store).map_err(err)?.is_none() {
             let manifest_blob = load_blob_data(self.store, &commit.manifest)?;
             let manifest = permguard_objects::manifest::Manifest::decode(&manifest_blob)
                 .map_err(|error| err(error.to_string()))?;
             let yaml = manifest_file::to_yaml(&manifest).map_err(err)?;
-            self.store
-                .write(manifest_file::MANIFEST_YML, yaml.as_bytes())
-                .map_err(err)?;
-            written.push(manifest_file::MANIFEST_YML.to_owned());
+            plan.creates
+                .push((manifest_file::MANIFEST_YML.to_owned(), yaml.into_bytes()));
         }
 
-        // Local ids: what the sources already hold, wherever they hold it.
+        // Local ids: what the sources already hold, wherever they hold it. A
+        // fresh clone has no sources, and a workspace whose sources do not
+        // build cannot be compared — both fall back to creates only, which is
+        // safe: `apply` needs the same build, so neither can lose a commit.
         let local: BTreeMap<String, PolicyRecord> = match self.refresh() {
             Ok(snapshot) => snapshot
                 .policies
                 .into_iter()
                 .map(|policy| (policy.id.clone(), policy))
                 .collect(),
-            // A fresh clone has no sources yet: everything materializes.
             Err(_) => BTreeMap::new(),
         };
 
-        for entry in &root.entries {
-            if entry.kind != Kind::Tree {
+        for (id, (digest, canonical)) in &incoming.policies {
+            let Some(held) = local.get(id) else {
+                // Not held here under any name: materialize it, unless
+                // something already occupies the name it would take.
+                if !self.store.exists(canonical) {
+                    plan.creates
+                        .push((canonical.clone(), load_blob_data(self.store, digest)?));
+                }
+                continue;
+            };
+            if &held.digest == digest {
                 continue;
             }
-            self.materialize_tree(&entry.name, &entry.digest, &local, &mut written)?;
+            let based = base.policies.get(id).map(|(digest, _)| digest);
+            if based == Some(digest) {
+                // Only the author moved it: that change is what `apply` sends.
+                continue;
+            }
+            // A source names a position inside a file when one file holds
+            // several policies. There is no whole file to overwrite then,
+            // only a fragment, so the author reconciles it.
+            if based == Some(&held.digest) && !held.source.contains('#') {
+                plan.updates
+                    .push((held.source.clone(), load_blob_data(self.store, digest)?));
+                continue;
+            }
+            plan.conflicts.push(Conflict {
+                path: held.source.clone(),
+                incoming: Some(digest.clone()),
+            });
         }
-        Ok(written)
+
+        // Policies the incoming head dropped.
+        for (id, (digest, _)) in &base.policies {
+            if incoming.policies.contains_key(id) {
+                continue;
+            }
+            let Some(held) = local.get(id) else {
+                continue;
+            };
+            if &held.digest == digest && !held.source.contains('#') {
+                plan.removals.push(held.source.clone());
+            } else {
+                plan.conflicts.push(Conflict {
+                    path: held.source.clone(),
+                    incoming: None,
+                });
+            }
+        }
+
+        // Schemas and every other non-policy blob: no identity to track them
+        // by, so the path is the identity and the bytes are the comparison.
+        for (path, digest) in &incoming.others {
+            let theirs = load_blob_data(self.store, digest)?;
+            let Some(ours) = self.store.read(path).map_err(err)? else {
+                plan.creates.push((path.clone(), theirs));
+                continue;
+            };
+            if ours == theirs {
+                continue;
+            }
+            let based = match base.others.get(path) {
+                Some(based) => load_blob_data(self.store, based)?,
+                None => {
+                    plan.conflicts.push(Conflict {
+                        path: path.clone(),
+                        incoming: Some(digest.clone()),
+                    });
+                    continue;
+                }
+            };
+            if based == theirs {
+                continue;
+            }
+            if based == ours {
+                plan.updates.push((path.clone(), theirs));
+            } else {
+                plan.conflicts.push(Conflict {
+                    path: path.clone(),
+                    incoming: Some(digest.clone()),
+                });
+            }
+        }
+
+        for (path, digest) in &base.others {
+            if incoming.others.contains_key(path) {
+                continue;
+            }
+            let Some(ours) = self.store.read(path).map_err(err)? else {
+                continue;
+            };
+            if ours == load_blob_data(self.store, digest)? {
+                plan.removals.push(path.clone());
+            } else {
+                plan.conflicts.push(Conflict {
+                    path: path.clone(),
+                    incoming: None,
+                });
+            }
+        }
+
+        Ok(plan)
     }
 }
 
-impl Workspace<'_> {
-    /// Materializes one subtree, recursing — the folder structure of the
-    /// snapshot (a Rego package tree, say) is rebuilt exactly: directory
-    /// names are the subtree entry names.
-    fn materialize_tree(
-        &self,
-        directory: &str,
-        tree_digest: &Digest,
-        local: &BTreeMap<String, PolicyRecord>,
-        written: &mut Vec<String>,
-    ) -> Result<()> {
-        let tree = load_tree(self.store, tree_digest)?;
-        for item in &tree.entries {
-            match item.kind {
-                Kind::Tree => {
-                    self.materialize_tree(
-                        &format!("{directory}/{}", item.name),
-                        &item.digest,
-                        local,
-                        written,
-                    )?;
-                }
-                Kind::Blob => match item.annotations.get(ANNOTATION_POLICY_ID) {
-                    Some(id) => {
-                        if local.contains_key(id) {
-                            continue;
-                        }
-                        let stem = item
-                            .annotations
-                            .get(ANNOTATION_POLICY_ALIAS)
-                            .cloned()
-                            .unwrap_or_else(|| id.clone());
-                        let extension = item.name.rsplit('.').next().unwrap_or("txt");
-                        let path = format!("{directory}/{stem}.{extension}");
-                        if !self.store.exists(&path) {
-                            let data = load_blob_data(self.store, &item.digest)?;
-                            self.store.write(&path, &data).map_err(err)?;
-                            written.push(path);
-                        }
-                    }
-                    None => {
-                        // A schema or other non-policy blob: keep its name.
-                        let path = format!("{directory}/{name}", name = item.name);
-                        if !self.store.exists(&path) {
-                            let data = load_blob_data(self.store, &item.digest)?;
-                            self.store.write(&path, &data).map_err(err)?;
-                            written.push(path);
-                        }
-                    }
-                },
-                Kind::Commit => {}
+/// What a pull does to the working tree, decided before anything is written.
+#[derive(Debug, Default)]
+pub(crate) struct Materialization {
+    /// Files the tree does not hold: path and content.
+    creates: Vec<(String, Vec<u8>)>,
+    /// Files the incoming head moved and the author had not: path and content.
+    updates: Vec<(String, Vec<u8>)>,
+    /// Files the incoming head dropped and the author had not touched.
+    removals: Vec<String>,
+    /// Files both sides moved. Non-empty means the pull does not happen.
+    conflicts: Vec<Conflict>,
+}
+
+impl Materialization {
+    /// The paths created, in the order they were written.
+    fn created(&self) -> Vec<String> {
+        self.creates.iter().map(|(path, _)| path.clone()).collect()
+    }
+
+    /// The paths advanced to the incoming head's content.
+    fn updated(&self) -> Vec<String> {
+        self.updates.iter().map(|(path, _)| path.clone()).collect()
+    }
+
+    /// The refusal: every file the author has to reconcile, and how to read
+    /// what the remote holds so they can.
+    fn refusal(&self) -> String {
+        let mut message = String::from(
+            "the incoming head changes files this workspace also changed: reconcile them, then \
+             pull again",
+        );
+        for conflict in &self.conflicts {
+            match &conflict.incoming {
+                Some(digest) => message.push_str(&format!(
+                    "\n  - {path}: changed here and on the remote — read the remote's version \
+                     with `permguard objects cat {digest}`",
+                    path = conflict.path,
+                )),
+                None => message.push_str(&format!(
+                    "\n  - {path}: the remote dropped it and this workspace changed it — delete \
+                     the file to accept the removal, or apply it back",
+                    path = conflict.path,
+                )),
             }
         }
-        Ok(())
+        message
     }
+}
+
+/// One file the incoming head and the author both moved.
+#[derive(Debug)]
+struct Conflict {
+    /// The local file, as the author knows it.
+    path: String,
+    /// What the remote holds, so `permguard objects cat` can show it. `None`
+    /// when the remote dropped the file altogether.
+    incoming: Option<Digest>,
+}
+
+/// Every blob one head materializes, keyed the way the working tree keys it:
+/// policies by identity, because the author may keep one under any file name;
+/// everything else by the path it lands at.
+#[derive(Debug, Default)]
+struct HeadContents {
+    /// Policy id → its blob, and the path a fresh materialization writes it to.
+    policies: BTreeMap<String, (Digest, String)>,
+    /// Non-policy blobs: path → blob.
+    others: BTreeMap<String, Digest>,
+}
+
+/// Reads one head's contents from the local store.
+fn head_contents(store: &dyn Store, head: &Digest) -> Result<HeadContents> {
+    let commit = load_commit(store, head)?;
+    let root = load_tree(store, &commit.tree)?;
+    let mut contents = HeadContents::default();
+    for entry in &root.entries {
+        if entry.kind != Kind::Tree {
+            continue;
+        }
+        read_tree_contents(store, &entry.name, &entry.digest, &mut contents)?;
+    }
+    Ok(contents)
+}
+
+/// Reads one subtree, recursing — the folder structure of the snapshot (a
+/// Rego package tree, say) is keyed exactly: directory names are the subtree
+/// entry names.
+fn read_tree_contents(
+    store: &dyn Store,
+    directory: &str,
+    tree_digest: &Digest,
+    contents: &mut HeadContents,
+) -> Result<()> {
+    let tree = load_tree(store, tree_digest)?;
+    for item in &tree.entries {
+        match item.kind {
+            Kind::Tree => read_tree_contents(
+                store,
+                &format!("{directory}/{name}", name = item.name),
+                &item.digest,
+                contents,
+            )?,
+            Kind::Blob => match item.annotations.get(ANNOTATION_POLICY_ID) {
+                Some(id) => {
+                    let stem = item
+                        .annotations
+                        .get(ANNOTATION_POLICY_ALIAS)
+                        .cloned()
+                        .unwrap_or_else(|| id.clone());
+                    let extension = item.name.rsplit('.').next().unwrap_or("txt");
+                    contents.policies.insert(
+                        id.clone(),
+                        (
+                            item.digest.clone(),
+                            format!("{directory}/{stem}.{extension}"),
+                        ),
+                    );
+                }
+                None => {
+                    // A schema or other non-policy blob: keep its name.
+                    contents.others.insert(
+                        format!("{directory}/{name}", name = item.name),
+                        item.digest.clone(),
+                    );
+                }
+            },
+            Kind::Commit => {}
+        }
+    }
+    Ok(())
+}
+
+/// The commit this workspace last converged on, or `None` before the first.
+fn tracked_head(store: &dyn Store) -> Result<Option<Digest>> {
+    let r#ref = config::read_head(store)
+        .map_err(err)?
+        .unwrap_or_else(|| super::DEFAULT_REF.to_owned());
+    let Some(checkpoint) = config::read_checkpoint(store, &r#ref).map_err(err)? else {
+        return Ok(None);
+    };
+    Digest::parse(&checkpoint.head)
+        .map(Some)
+        .map_err(|_| err("corrupt checkpoint"))
 }
 
 /// The identity hooks of the previous (tracked) snapshot: entry path → id,

--- a/crates/permguard-cli/src/main.rs
+++ b/crates/permguard-cli/src/main.rs
@@ -215,7 +215,9 @@ fn run(cli: Cli) -> Result<ExitCode, Failure> {
         Command::Checkout { reference } => {
             workspace_command(&globals, WorkspaceOp::Checkout { reference }, &trace)
         }
-        Command::Pull => workspace_command(&globals, WorkspaceOp::Pull, &trace),
+        Command::Pull { resolved } => {
+            workspace_command(&globals, WorkspaceOp::Pull { resolved }, &trace)
+        }
         Command::Refresh => workspace_command(&globals, WorkspaceOp::Refresh, &trace),
         Command::Validate => workspace_command(&globals, WorkspaceOp::Validate, &trace),
         Command::Test {

--- a/crates/permguard-cli/src/workspace_out.rs
+++ b/crates/permguard-cli/src/workspace_out.rs
@@ -133,6 +133,17 @@ pub struct PullReport {
     pub head: String,
     pub fetched: usize,
     pub materialized: Vec<String>,
+    /// Files advanced to the incoming head's content.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub updated: Vec<String>,
+    /// Files the incoming head dropped.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub removed: Vec<String>,
+    /// The counter held before the pull, when one was held. Not serialized: it
+    /// is here to tell "nothing to do" from "the ref moved", and `counter`
+    /// already carries where the workspace landed.
+    #[serde(skip)]
+    pub previous_counter: Option<u64>,
 }
 
 impl Report for PullReport {
@@ -150,26 +161,43 @@ impl Report for PullReport {
         for path in &self.materialized {
             writeln!(out, "  {} {}", style::create("+"), style::create(path))?;
         }
+        for path in &self.updated {
+            writeln!(out, "  {} {}", style::modify("~"), style::modify(path))?;
+        }
+        for path in &self.removed {
+            writeln!(out, "  {} {}", style::delete("-"), style::delete(path))?;
+        }
+        // "Already up to date" has to mean the pull found nothing to do, not
+        // that it fetched nothing: a refused pull leaves its objects in the
+        // store, so `pull --resolved` fetches none and still moves the ref.
+        let moved = self.fetched > 0
+            || !self.materialized.is_empty()
+            || !self.updated.is_empty()
+            || !self.removed.is_empty()
+            || self
+                .previous_counter
+                .is_some_and(|held| held != self.counter);
         let outcome = match self.action {
             "clone" => "Clone complete.",
             "checkout" => "Checkout complete.",
+            _ if moved => "Pull complete.",
             _ => "Already up to date.",
-        };
-        let outcome = if self.fetched > 0 && self.action == "pull" {
-            "Pull complete."
-        } else {
-            outcome
         };
         write!(out, "{} ", style::ok(&style::bold(outcome)))?;
         if let Some(directory) = &self.directory {
             write!(out, "Into `{directory}` — ")?;
         }
+        // Written, advanced and removed are counted apart: "files written"
+        // alone read like a no-op success on the pull that advanced content.
         writeln!(
             out,
-            "counter {}, {} objects fetched, {} files written (signed head verified).",
+            "counter {}, {} objects fetched, {} files written, {} advanced, {} removed (signed \
+             head verified).",
             self.counter,
             self.fetched,
-            self.materialized.len()
+            self.materialized.len(),
+            self.updated.len(),
+            self.removed.len()
         )?;
         writeln!(out, "  head {}", style::id(&self.head))
     }
@@ -866,6 +894,9 @@ mod tests {
             head: "sha256:ff".into(),
             fetched: 2,
             materialized: vec!["app/x.cedar".into()],
+            updated: vec![],
+            removed: vec![],
+            previous_counter: Some(2),
         };
         assert!(terminal(&base).contains("Pull complete."));
 
@@ -886,8 +917,44 @@ mod tests {
             head: String::new(),
             fetched: 0,
             materialized: vec![],
+            updated: vec![],
+            removed: vec![],
+            previous_counter: None,
         };
         assert!(terminal(&empty).contains("Bound."), "an empty ledger binds");
+    }
+
+    #[test]
+    fn a_pull_that_only_moves_the_ref_still_says_it_pulled() {
+        // What `pull --resolved` looks like after a refused pull: the objects
+        // are already in the store, the tree was reconciled by hand, so
+        // nothing is fetched and nothing is written — and the ref still moves.
+        let resolved = PullReport {
+            action: "pull",
+            reference: None,
+            directory: None,
+            counter: 8,
+            head: "sha256:ff".into(),
+            fetched: 0,
+            materialized: vec![],
+            updated: vec![],
+            removed: vec![],
+            previous_counter: Some(7),
+        };
+        let text = terminal(&resolved);
+        assert!(
+            text.contains("Pull complete."),
+            "a pull that advanced the ref cannot claim there was nothing to do: {text}"
+        );
+
+        let standing = PullReport {
+            counter: 7,
+            ..resolved
+        };
+        assert!(
+            terminal(&standing).contains("Already up to date."),
+            "a pull that changed nothing says so"
+        );
     }
 
     #[test]

--- a/crates/permguard-cli/tests/engine_e2e.rs
+++ b/crates/permguard-cli/tests/engine_e2e.rs
@@ -266,7 +266,7 @@ fn the_whole_developer_flow() {
     assert_eq!(applied_b.counter, 2);
 
     // ---- author one converges: pull, files untouched but content advanced ----
-    let pulled_a = ws_a.pull(&remote).unwrap();
+    let pulled_a = ws_a.pull(&remote, false).unwrap();
     assert_eq!(pulled_a.counter, 2);
     // The edited policy keeps its identity: same alias, same id, so nothing
     // new materializes as a file (the author's file stays the author's).
@@ -275,15 +275,130 @@ fn the_whole_developer_flow() {
         "{:?}",
         pulled_a.materialized
     );
+    // The author's file, though, now holds the other author's content. A
+    // checkpoint at counter 2 over a tree still holding counter 1 is how the
+    // next apply reverts a commit nobody asked it to touch.
+    // It lands in *their* file, `billing.cedar` — the identity is the policy
+    // id, not the name the other author happens to keep it under.
+    assert_eq!(
+        pulled_a.updated,
+        vec!["cedar/billing.cedar".to_owned()],
+        "the remote's change has to land in the file the author holds it in"
+    );
+    let landed = String::from_utf8(store_a.read("cedar/billing.cedar").unwrap().unwrap()).unwrap();
+    assert!(
+        landed.contains("Action::\"list\""),
+        "author one's file did not advance: {landed}"
+    );
+    // And so the tree agrees with the checkpoint: nothing to apply.
+    let (_, converged) = ws_a.plan().unwrap();
+    assert!(
+        converged.actions.is_empty(),
+        "a converged workspace plans nothing: {converged:?}"
+    );
 
     // History shows both commits.
     let history = ws_a.history().unwrap();
     assert_eq!(history.len(), 2);
 
     // A second pull is a clean no-op at the same counter.
-    let same = ws_a.pull(&remote).unwrap();
+    let same = ws_a.pull(&remote, false).unwrap();
     assert_eq!(same.counter, 2);
     assert_eq!(same.fetched, 0);
+}
+
+/// Both authors change the same policy: the pull refuses instead of
+/// advancing the checkpoint over content the tree does not hold, and names
+/// the object so the author can read the version they have to reconcile with.
+#[test]
+fn a_pull_does_not_advance_over_a_conflict() {
+    let remote = EngineRemote::new("conflict");
+
+    // A workspace bound to the test remote. The store outlives the borrow.
+    fn bind(store: &FsStore) -> Workspace<'_> {
+        let ws = Workspace::open(store);
+        ws.init("acme-authz", &["cedar", "rego"]).unwrap();
+        let mut config = ws.config().unwrap();
+        config.remotes.insert(
+            "origin".into(),
+            permguard_cli::engine::workspace::config::RemoteConfig {
+                url: "test://".into(),
+                tls_ca_file: None,
+            },
+        );
+        ws.save_config(&config).unwrap();
+        ws
+    }
+
+    // Author one publishes the base.
+    let store_a = FsStore::new(scratch("conflict-a"));
+    let ws_a = bind(&store_a);
+    store_a
+        .write("cedar/billing.cedar", CEDAR.as_bytes())
+        .unwrap();
+    store_a.write("rego/routes.rego", REGO.as_bytes()).unwrap();
+    let _ = ws_a.checkout(&remote, "origin", "delivery", "main-ledger", "main");
+    assert_eq!(
+        ws_a.apply(&remote, "a@acme.com", "base").unwrap().counter,
+        1
+    );
+
+    // Author two clones it.
+    let store_b = FsStore::new(scratch("conflict-b"));
+    let ws_b = bind(&store_b);
+    std::fs::remove_file(store_b.root().join("manifest.yml")).unwrap();
+    ws_b.checkout(&remote, "origin", "delivery", "main-ledger", "main")
+        .unwrap();
+
+    // Both edit the same policy, differently. Author one gets there first.
+    store_a
+        .write(
+            "cedar/billing.cedar",
+            CEDAR
+                .replace("Action::\"read\"", "Action::\"list\"")
+                .as_bytes(),
+        )
+        .unwrap();
+    assert_eq!(
+        ws_a.apply(&remote, "a@acme.com", "list").unwrap().counter,
+        2
+    );
+    store_b
+        .write(
+            "cedar/billing-ro.cedar",
+            CEDAR
+                .replace("Action::\"read\"", "Action::\"purge\"")
+                .as_bytes(),
+        )
+        .unwrap();
+
+    // Author two is refused the push, told to pull — and the pull refuses
+    // too, rather than quietly making the next apply a revert.
+    assert!(ws_b.apply(&remote, "b@acme.com", "purge").is_err());
+    let refused = ws_b.pull(&remote, false).unwrap_err().to_string();
+    assert!(
+        refused.contains("cedar/billing-ro.cedar") && refused.contains("objects cat"),
+        "the refusal has to name the file and how to read theirs: {refused}"
+    );
+
+    // Nothing moved: the checkpoint still says 1, so the apply still refuses
+    // and author one's commit cannot be lost.
+    assert_eq!(ws_b.status().unwrap().checkpoint.unwrap().counter, 1);
+    assert!(ws_b.apply(&remote, "b@acme.com", "purge").is_err());
+    let held = String::from_utf8(store_b.read("cedar/billing-ro.cedar").unwrap().unwrap()).unwrap();
+    assert!(
+        held.contains("Action::\"purge\""),
+        "the tree was not touched"
+    );
+
+    // Reconciled by hand, `--resolved` lets it through, and the apply lands
+    // on top of author one's commit instead of replacing it.
+    ws_b.pull(&remote, true).unwrap();
+    assert_eq!(ws_b.status().unwrap().checkpoint.unwrap().counter, 2);
+    assert_eq!(
+        ws_b.apply(&remote, "b@acme.com", "purge").unwrap().counter,
+        3
+    );
 }
 
 #[test]

--- a/crates/permguard-cli/tests/engine_sync_hostile.rs
+++ b/crates/permguard-cli/tests/engine_sync_hostile.rs
@@ -304,7 +304,7 @@ fn advance_remote(remote: &EngineRemote) {
                 .as_bytes(),
         )
         .unwrap();
-    ws_b.pull(remote).unwrap();
+    ws_b.pull(remote, false).unwrap();
     ws_b.apply(remote, "tester-b", "advance").unwrap();
 }
 
@@ -322,7 +322,7 @@ fn an_object_nobody_asked_for_is_refused_and_the_checkpoint_stays() {
         lie: Lie::SmuggleObject,
     };
     let error = Workspace::open(&store)
-        .pull(&hostile)
+        .pull(&hostile, false)
         .expect_err("a smuggled object must be refused");
 
     assert!(error.message.contains("not asked for"), "{}", error.message);
@@ -345,7 +345,7 @@ fn a_withheld_closure_is_refused_and_the_checkpoint_stays() {
         lie: Lie::WithholdObjects,
     };
     let error = Workspace::open(&store)
-        .pull(&hostile)
+        .pull(&hostile, false)
         .expect_err("an incomplete closure must be refused");
 
     assert!(
@@ -376,7 +376,7 @@ fn a_head_signed_by_a_foreign_key_is_refused_everywhere_it_appears() {
 
     // The pull path refuses before anything advances.
     let error = ws
-        .pull(&hostile)
+        .pull(&hostile, false)
         .expect_err("a forged head must be refused");
     assert!(
         error.message.contains("does not verify"),
@@ -446,7 +446,8 @@ fn without_a_tracked_ledger_the_syncing_commands_say_what_to_do() {
     ws.init("untracked", &["cedar"]).unwrap();
 
     for error in [
-        ws.pull(&remote).expect_err("pull needs a tracked ledger"),
+        ws.pull(&remote, false)
+            .expect_err("pull needs a tracked ledger"),
         ws.apply(&remote, "t", "m")
             .expect_err("apply needs a tracked ledger"),
         ws.verify(&remote)
@@ -473,7 +474,7 @@ fn a_corrupt_local_checkpoint_stops_the_sync_instead_of_trusting_it() {
         .unwrap();
 
     let error = Workspace::open(&store)
-        .pull(&honest)
+        .pull(&honest, false)
         .expect_err("a corrupt checkpoint must stop the pull");
     assert!(
         error.message.to_lowercase().contains("checkpoint"),

--- a/crates/permguard-languages/src/dogwood/compiled.rs
+++ b/crates/permguard-languages/src/dogwood/compiled.rs
@@ -1055,18 +1055,20 @@ impl CompiledDogwood {
             })
             .collect();
 
+        // The refusal is built inside, not outside: upstream's entity error is a large value, and
+        // a closure that returned it would carry it out through every frame this grows.
         crate::headroom::with(|| {
             Entities::from_json_value(serde_json::Value::Array(store), Some(&self.cedar_schema))
-        })
-        .map(|_| ())
-        .map_err(|error| {
-            Refused::new(
-                "event_entities_rejected",
-                format!(
-                    "the attributed entity store does not conform to this partition's action \
-                         schema: {error}"
-                ),
-            )
+                .map(|_| ())
+                .map_err(|error| {
+                    Refused::new(
+                        "event_entities_rejected",
+                        format!(
+                            "the attributed entity store does not conform to this partition's \
+                             action schema: {error}"
+                        ),
+                    )
+                })
         })
     }
 }

--- a/crates/permguard-languages/src/headroom.rs
+++ b/crates/permguard-languages/src/headroom.rs
@@ -55,3 +55,59 @@ const GROW_TO: usize = 8 * 1024 * 1024;
 pub fn with<T>(work: impl FnOnce() -> T) -> T {
     stacker::maybe_grow(RED_ZONE, GROW_TO, work)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{GROW_TO, RED_ZONE};
+
+    /// The guarantee, on a thread that does not have the room to begin with.
+    ///
+    /// This is the whole defect in one assertion: Cedar asks
+    /// [`stacker::remaining_stack`] for [`RED_ZONE`] and declines the evaluation
+    /// when it is not there, so entering an engine on a thread that reports less
+    /// is entering it to be refused. A small explicit stack reproduces on any
+    /// platform what musl reports on the process's first thread.
+    #[test]
+    fn an_engine_is_entered_with_room_to_recurse_in() {
+        let starved = std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(|| {
+                let before = stacker::remaining_stack();
+                assert!(
+                    before.is_some_and(|remaining| remaining < RED_ZONE),
+                    "the thread was meant to start short of the red zone: {before:?}"
+                );
+                super::with(stacker::remaining_stack)
+            })
+            .expect("spawn")
+            .join()
+            .expect("join");
+
+        assert!(
+            starved.is_some_and(|remaining| remaining >= RED_ZONE),
+            "an engine would decline rather than answer with {starved:?} of stack"
+        );
+    }
+
+    /// A thread that already has the room is not made to pay for a segment.
+    #[test]
+    fn room_already_there_is_left_alone() {
+        let before = stacker::remaining_stack();
+        let inside = super::with(stacker::remaining_stack);
+        if let (Some(before), Some(inside)) = (before, inside)
+            && before >= RED_ZONE
+        {
+            assert!(
+                inside <= before,
+                "no segment should have been claimed: {before} -> {inside}"
+            );
+        }
+    }
+
+    /// The claim is at least as large as the guarantee, or growing would not
+    /// satisfy the guard it exists for.
+    #[test]
+    fn the_claim_covers_the_guarantee() {
+        const { assert!(GROW_TO >= RED_ZONE) };
+    }
+}


### PR DESCRIPTION
<!-- Copyright (c) 2022 Nitro Agility S.r.l. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

`fix(cli): land the incoming head in the working tree, so a pull cannot leave the checkpoint ahead of the files`

## What this changes

`pull` now materializes the head it just verified, instead of only creating the files the
working tree happened to lack. A tracked file the remote moved is advanced, a tracked file
the remote dropped is removed, and a file both sides moved refuses the pull rather than
advancing over it. Two authors on one ledger can no longer destroy each other's commits by
following the instructions the CLI itself prints.

## Why

`pull` only ever *created* files. A policy already present on disk was skipped whatever the
incoming head said about it — the skip keyed on whether the policy id existed locally, not on
whether the author had changed it:

```rust
if local.contains_key(id) { continue; }
```

The checkpoint advanced anyway. `apply` diffs the working tree against the checkpoint, so
content the tree never received read as a deliberate deletion, and the next `apply` reverted
the other author's commit, reported success, and exited 0. The `ref_conflict` guard only
protects against a stale *counter*, and the `pull` had just satisfied it. `0 files written`
was the only signal, and it reads like a no-op success.

The intent behind the skip — never clobber the author's uncommitted work — is right, and is
kept. Keying it on *presence* rather than on *modification* is what made it apply to files
the author had never touched, which is why **a workspace with no local changes at all was
enough** to lose a commit.

Two further consequences of the same line: a policy the remote deleted stayed on disk and
came back as `2 to create` on the next `plan`, silently undoing a revocation; and because a
clone names files by the policy's alias, a workspace holding the same policy under a
different filename never received updates to it at all.

`pull`'s own doc comment states the invariant this broke — *"a failure writing sources can
never leave the checkpoint claiming more than the disk holds"* — and it was being broken on
the success path, not on failure.

## How this fixes it

Materialization is now three-way, and fully decided before a byte is written: the tracked
head is the base, the working tree is the author's side, the incoming head is the remote's.

- a file only the remote moved is advanced — written into **the author's** file, since a
  policy's identity is its id and not the name the author keeps it under;
- a file only the author moved is left alone: that change is what `apply` is for;
- a file the remote dropped and the author had not touched is removed;
- a file both sides moved is a conflict. The pull refuses: nothing written, checkpoint not
  advanced, so `apply` still refuses with `ref_conflict` and no commit can be lost.

The refusal names each file and the object to read the remote's version with:

```
error: the incoming head changes files this workspace also changed: reconcile them, then pull again
  - rego/gateway-access.rego: changed here and on the remote — read the remote's version with
    `permguard objects cat sha256:970e6f99…`
```

`pull --resolved` accepts the working tree as already reconciled and advances, which is the
way out after merging by hand. That flag replaces what used to be the silent default.

`pull`, `checkout` and `clone` now count what they advanced and removed alongside what they
wrote, because `0 files written` alone read like a no-op on the pull that changed content:

```
  ~ rego/gateway-access.rego
Pull complete. counter 2, 4 objects fetched, 0 files written, 1 advanced, 0 removed (signed head verified).
```

And `Already up to date.` now means the pull found nothing to do, rather than that it fetched
nothing. The two are not the same once a pull can refuse: the refused pull has already put the
objects in the local store, so the `--resolved` retry fetches none, writes none — the tree was
reconciled by hand — and still moves the ref. It used to announce there was nothing new on the
one pull whose whole purpose was to accept a new head.

## Also in this PR: the follow-up #135 landed without

`#135` was squash-merged before its follow-up could be pushed, so `main` carries the version
whose entity check builds the refusal *outside* the frame `headroom::with` grows. Upstream's
entity error is a large value, so carrying it out through every one of those frames trips
`clippy::result_large_err` — 376 bytes, and `-D warnings` is the gate:

```
error: the `Err`-variant returned from this closure is very large
  --> crates/permguard-languages/src/dogwood/compiled.rs:1058:31
      the `Err`-variant is at least 376 bytes
  = note: `-D clippy::result-large-err` implied by `-D warnings`
```

`task lint` therefore fails on `main` as it stands, and on every PR opened against it, for a
reason that has nothing to do with the PR. This one carries the two-file follow-up so the gate
is green: the `Refused` is constructed inside the closure, and `headroom` gains the tests
`#135` went in without — a thread spawned with a 256 KiB stack reproduces on any platform what
musl reports for the process's first thread, and the test asserts `with` leaves at least
`RED_ZONE` beneath the engine. Replacing `with`'s body with a bare call fails it.

Two files, 68 insertions, reviewable on their own. They are here rather than in a PR of their
own because leaving `main` red would make this PR's own CI unreadable.

## How to reproduce

Two authors, one ledger, two named rules so the loss is unambiguous. Against a lab server
with a zone `acme`:

```sh
export SCRATCH=$(mktemp -d)
permguard ledgers create lost-update --zone acme

# author A: a copy of examples/basics, published as counter 1
cp -r examples/basics "$SCRATCH/wsA" && rm -rf "$SCRATCH/wsA/.permguard"
permguard -w "$SCRATCH/wsA" init wsa --language cedar,rego
permguard -w "$SCRATCH/wsA" remote add origin http://127.0.0.1:6443
permguard -w "$SCRATCH/wsA" checkout origin/acme/lost-update
permguard -w "$SCRATCH/wsA" apply -m "base"                     # -> counter 1

# author B: a clone of that same head
permguard clone http://127.0.0.1:6443/acme/lost-update "$SCRATCH/wsB"

# A commits ruleA
printf '\nallow if { input.subject.properties.role == "ruleA" }\n' \
  >> "$SCRATCH/wsA/rego/gateway.rego"
permguard -w "$SCRATCH/wsA" apply -m "ruleA from A"             # -> counter 2

# B, still on counter 1, commits ruleB
printf '\nallow if { input.subject.properties.role == "ruleB" }\n' \
  >> "$SCRATCH/wsB/rego/gateway-access.rego"
permguard -w "$SCRATCH/wsB" apply -m "ruleB from B"             # -> exit 64, ref_conflict

# B does exactly what the error message says
permguard -w "$SCRATCH/wsB" pull
grep -c ruleA "$SCRATCH/wsB/rego/gateway-access.rego"
permguard -w "$SCRATCH/wsB" apply -m "ruleB from B after pull"

# what actually survived
permguard clone http://127.0.0.1:6443/acme/lost-update "$SCRATCH/wsC"
echo "ruleA: $(grep -c ruleA "$SCRATCH/wsC/rego/gateway-access.rego")"
echo "ruleB: $(grep -c ruleB "$SCRATCH/wsC/rego/gateway-access.rego")"
```

Before, at the three decisive lines:

```
Pull complete. counter 2, 4 objects fetched, 0 files written (signed head verified)
                                             ^^^^^^^^^^^^^^^ ruleA never lands on disk
grep -c ruleA -> 0
Apply complete. Ref `main` advanced to counter 3            exit 0

ruleA: 0        <-- committed at counter 2, signed, verified, now destroyed
ruleB: 1
```

After: the `pull` refuses and names the file, the checkpoint stays at counter 1, `apply` still
refuses, and once reconciled by hand `pull --resolved` and `apply` reach counter 3 with
`ruleA: 1  ruleB: 1`.

Each branch was also measured end to end on a lab ledger: the remote advancing a file
(`1 advanced`, the rule lands, `plan` converges), the remote dropping two files
(`2 removed`), the remote renaming a policy's alias (the new name written, the old removed),
the true conflict (exit 64, nothing written, checkpoint held), and an author's local edit with
the remote unmoved (left alone, reported by `status` as pending).

## Contributor License Agreement

By opening this pull request you confirm that you have read and accept the
[Permguard Contributor License Agreement](https://github.com/permguard/.github/blob/main/CLA.md).
You keep ownership of what you contribute; the CLA grants Nitro Agility S.r.l.
the rights it needs to distribute it as part of Permguard, now and under future
licensing terms.

- [x] I have read and accept the Permguard Contributor License Agreement

## Checklist

- [x] `task check` passes locally (lint, structural checks, tests) — `lint`, `check:seams`,
      `check:core-deps`, `check:systems` and `check:notices` are green. `lint` is green *because*
      of the `#135` follow-up above; without those two files it fails on `main` and would fail
      here. Two pre-existing
      failures this PR does not touch: `check:headers` on eight files unmodified by this
      branch (`CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `GOVERNANCE.md`, `SECURITY.md`,
      `TRADEMARKS.md`, `docs/book.toml`, `docs/src/SUMMARY.md`, `docs/src/chapter_1.md`), and
      `permguard-std --test secrets_stores` (`test_a_secret_on_disk_resolves_to_its_contents`,
      `test_the_newline_an_editor_adds_is_not_part_of_the_key`, both `Denied`). This change is
      confined to `permguard-cli`, which depends on `permguard-std` and not the reverse, so it
      cannot reach those tests. Each wants a PR of its own.
- [x] Tests cover the behaviour, not just the code path — `a_pull_does_not_advance_over_a_conflict`
      is new in `crates/permguard-cli/tests/engine_e2e.rs`: two authors edit the same policy, and
      it asserts the refusal names the file and `objects cat`, that the checkpoint does not move,
      that `apply` still refuses, that the tree is untouched, and that `--resolved` then advances.
      `the_whole_developer_flow` encoded the bug rather than catching it — it asserted
      `materialized.is_empty()` under a comment claiming the content had advanced, and never read
      the file; it now reads the file and asserts the workspace converges.
      `a_pull_that_only_moves_the_ref_still_says_it_pulled` covers the outcome wording: it fails
      with `Already up to date. counter 8` when the ref moved from 7, which is what the condition
      used to print. `permguard-cli`: 108 passed, 0 failed.
- [x] `CHANGELOG.md` updated under *Unreleased*, if this changes anything an operator can see
- [x] Any new configuration key, flag, metric, exit status or `reason` code is documented —
      `pull --resolved` is new, with help text and an example in `args.rs`. `pull` also gains a
      refusal path: it now exits 64 on a conflict where it previously exited 0.
- [x] `docs/compatibility.md` still describes reality, if this touches one of the listed
      interfaces — no such file in this tree

## Interfaces touched

- [x] Container images, chart values, or anything in a release artifact — the CLI, plus the
      `#135` follow-up in `permguard-languages` (an internal refactor of where a refusal is
      built, plus tests: no behaviour change). `pull`,
      `checkout` and `clone` gain `updated` and `removed` in their `-o json` output (both omitted
      when empty) and two extra counts plus `~`/`-` lines in the text output; `pull` gains an
      exit-64 conflict refusal. No server or wire interface changes.